### PR TITLE
Clean up Gemfile to be more idiomatic, remove ineffective method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'rspec'
-gem 'rubocop'
-gem 'rake'
-gem 'rainbow_documentation'
-
-gem 'colorize'
-gem 'psych'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+PATH
+  remote: .
+  specs:
+    rspec_log (0.0.7)
+      colorize
+      psych
+      rainbow_documentation
+      rake
+      rspec (~> 3.0)
+      rubocop
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -37,12 +48,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  colorize
-  psych
-  rainbow_documentation
-  rake
-  rspec
-  rubocop
+  rspec_log!
 
 BUNDLED WITH
-   1.12.5
+   1.13.5

--- a/lib/rspec_log.rb
+++ b/lib/rspec_log.rb
@@ -42,8 +42,6 @@ class RSpecLog
     log_hash_set(log_hash)
   end
 
-  private_class_method
-
   def self.write_hash_to_file(log_hash, filename = DEFAULT_LOG_FILE)
     File.open(filename, 'w') { |f| f.write(YAML.dump(log_hash, line_width: -1)) }
   end

--- a/rspec_log.gemspec
+++ b/rspec_log.gemspec
@@ -16,10 +16,12 @@ Gem::Specification.new do |s|
   s.authors     = ['Andrea Capri']
   s.email       = ['andrea.a.capri@gmail.com']
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '~> 3.0'
-
+  s.add_runtime_dependency 'rake'
+  s.add_runtime_dependency 'rspec', '~> 3.0'
   s.add_runtime_dependency 'colorize'
+  s.add_runtime_dependency 'psych'
+  s.add_runtime_dependency 'rainbow_documentation'
+  s.add_runtime_dependency 'rubocop'
 
   s.require_path  = 'lib'
   s.files         = %w(LICENSE README.md) + Dir.glob('{lib}/**/*')


### PR DESCRIPTION
The `private_class_method` in `rspec_log.rb` was not doing anything and
  honestly a little confusing. I removed it for clarity. (Originally I
  made those methods actually private class methods but then the rest of the
  code broke)

Ruby gems usually specify all of their dependencies in their `.gemspec` file
  and have the `Gemfile` reference that. This does that now.
